### PR TITLE
Cross-compile for Scala 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ HBase RDD
 
 ![logo](https://raw.githubusercontent.com/unicredit/hbase-rdd/master/docs/logo.png)
 
-This project allows to connect Apache Spark to HBase. Currently it is compiled with Scala 2.10, using the versions of Spark and HBase available on CDH5.5. Version `0.6.0` of this project works on CDH5.3, version `0.4.0` works on CDH5.1 and version `0.2.2-SNAPSHOT` works on CDH5.0. Other combinations of versions may be made available in the future.
+This project allows to connect Apache Spark to HBase. Currently it is compiled with Scala 2.10 and 2.11, using the versions of Spark and HBase available on CDH5.5. Version `0.6.0` of this project works on CDH5.3, version `0.4.0` works on CDH5.1 and version `0.2.2-SNAPSHOT` works on CDH5.0. Other combinations of versions may be made available in the future.
 
 Table of contents
 -----------------

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "eu.unicredit"
 
 version := "0.7.1"
 
-scalaVersion := "2.10.6"
+crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 scalacOptions ++= Seq(
   "-deprecation",


### PR DESCRIPTION
Spark 2.0 is using 2.11 by default, making `hbase-rdd` compatible.

This would really help us with Spark 2.0 migration. Thanks.

@fralken