### PR TITLE
Cross build for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,10 @@
-import SonatypeKeys._
-
-sonatypeSettings
-
 name := "hbase-rdd"
 
 organization := "eu.unicredit"
 
 version := "0.8.0"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8")
+crossScalaVersions := Seq("2.11.12", "2.12.8")
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -18,14 +14,12 @@ scalacOptions ++= Seq(
   "-language:reflectiveCalls"
 )
 
-org.scalastyle.sbt.ScalastylePlugin.Settings
-
 resolvers ++= Seq(
   "Cloudera repos" at "https://repository.cloudera.com/artifactory/cloudera-repos",
   "Cloudera releases" at "https://repository.cloudera.com/artifactory/libs-release"
 )
 
-val sparkVersion = "1.5.0"
+val sparkVersion = "2.4.3"
 val hbaseVersion = "1.0.0-cdh5.5.2"
 val hadoopVersion = "2.6.0-cdh5.5.2"
 
@@ -36,7 +30,7 @@ libraryDependencies ++= Seq(
   "org.apache.hbase" % "hbase-server" % hbaseVersion % "provided",
   "org.json4s" %% "json4s-jackson" % "3.2.11" % "provided",
   // for tests
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "org.apache.hbase" % "hbase-common" % hbaseVersion % "test" classifier "tests",
   "org.apache.hbase" % "hbase-server" % hbaseVersion % "test" classifier "tests" exclude("org.mortbay.jetty", "servlet-api-2.5"),
   "org.apache.hbase" % "hbase-hadoop-compat" % hbaseVersion % "test",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.5.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"


### PR DESCRIPTION
Scala 2.10 has been EOL for a very long time, and HBaseRDD depends on Spark 1.5 which is EOL for a very long time as well.

In this PR, we enable cross-build for Scala 2.11 and Scala 2.12, and we also upgrade the Spark dependency into Spark 2.4.3.

@fralken 